### PR TITLE
Archive url toggle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,40 +13,14 @@ import Article from './components/Article'
 import { getCachedIndex, cacheIndex, getCachedYear, cacheYear } from './utils/indexedDB'
 
 // Layout component that wraps all routes
-function AppLayout({ children, currentPath }) {
+function AppLayout({ children,  useLocalImages,
+  setUseLocalImages,
+  useArchivedUrls,
+  setUseArchivedUrls }) {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
-  const [useLocalImages, setUseLocalImages] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('useLocalImages')
-      return saved === 'true'
-    }
-    return false
-  })
-  const [useArchivedUrls, setUseArchivedUrls] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('useArchivedUrls')
-      return saved === 'true'
-    }
-    return false
-  })
-  const initialUseLocalImages = useRef(null)
-  const initialUseArchivedUrls = useRef(null)
 
   function settingsMenuToggle(isOpen) {
     setIsSettingsOpen(isOpen)
-    if (isOpen) {
-      // Save values when modal opens
-      initialUseLocalImages.current = useLocalImages
-      initialUseArchivedUrls.current = useArchivedUrls
-    }
-    if (!isOpen) {
-      // Compare when modal closes
-      if (useLocalImages !== initialUseLocalImages.current || 
-          useArchivedUrls !== initialUseArchivedUrls.current) {
-        window.location.reload()
-        
-      }
-    }
   }
 
   const navigate = useNavigate()
@@ -149,7 +123,7 @@ function AppLayout({ children, currentPath }) {
 }
 
 // Comics viewer component (shared state)
-function ComicsView() {
+function ComicsView({ useLocalImages, useArchivedUrls }) {
   const navigate = useNavigate()
   const location = useLocation()
   const { date } = useParams()
@@ -171,20 +145,6 @@ function ComicsView() {
   const [backgroundLoadingYear, setBackgroundLoadingYear] = useState(null)
   const [backgroundLoadedCount, setBackgroundLoadedCount] = useState(0)
   const [backgroundTotalYears, setBackgroundTotalYears] = useState(0)
-  const [useLocalImages, setUseLocalImages] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('useLocalImages')
-      return saved === 'true'
-    }
-    return false
-  })
-  const [useArchivedUrls, setUseArchivedUrls] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('useArchivedUrls')
-      return saved === 'true'
-    }
-    return true
-  })
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
 
   const baseUrl = import.meta.env.BASE_URL
@@ -941,16 +901,6 @@ function ComicsView() {
           </div>
       ) : null}
 
-      {/* Settings Modal */}
-      <SettingsModal
-        isOpen={isSettingsOpen}
-        onClose={() => settingsMenuToggle(false)}
-        useLocalImages={useLocalImages}
-        setUseLocalImages={setUseLocalImages}
-        useArchivedUrls={useArchivedUrls}
-        setUseArchivedUrls={setUseArchivedUrls}
-      />
-
       {/* Background Loading Status */}
       {backgroundLoading && (
         <div className="fixed bottom-14 left-4 z-50 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 p-3 min-w-[220px]">
@@ -1005,10 +955,40 @@ function ArticleRoute() {
 
 // Main App component with routing
 function App() {
+    const [useLocalImages, setUseLocalImages] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const saved = localStorage.getItem('useLocalImages')
+      return saved === 'true'
+    }
+    return false
+  })
+
+  const [useArchivedUrls, setUseArchivedUrls] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const saved = localStorage.getItem('useArchivedUrls')
+      return saved === 'true'
+    }
+    return false
+  })
+
   return (
     <Routes>
-      <Route path="/" element={<AppLayout><ComicsView /></AppLayout>} />
-      <Route path="/comic/:date" element={<AppLayout><ComicsView /></AppLayout>} />
+      <Route path="/" element={
+        <AppLayout 
+          useLocalImages={useLocalImages} 
+          setUseLocalImages={setUseLocalImages} 
+          useArchivedUrls={useArchivedUrls} 
+          setUseArchivedUrls={setUseArchivedUrls}>
+          <ComicsView useLocalImages={useLocalImages} useArchivedUrls={useArchivedUrls} />
+        </AppLayout>} />  
+      <Route path="/comic/:date" element={
+        <AppLayout 
+          useLocalImages={useLocalImages} 
+          setUseLocalImages={setUseLocalImages} 
+          useArchivedUrls={useArchivedUrls} 
+          setUseArchivedUrls={setUseArchivedUrls}>
+          <ComicsView useLocalImages={useLocalImages} useArchivedUrls={useArchivedUrls} />
+        </AppLayout>} />
       <Route path="/comic" element={<Navigate to="/" replace />} />
       <Route path="/articles" element={<AppLayout><ArticlesRoute /></AppLayout>} />
       <Route path="/articles/:articleId" element={<AppLayout><ArticleRoute /></AppLayout>} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { Routes, Route, Navigate, useNavigate, useParams, useLocation, Link } from 'react-router-dom'
 import SearchBar from './components/SearchBar'
 import DatePicker from './components/DatePicker'
@@ -22,6 +22,33 @@ function AppLayout({ children, currentPath }) {
     }
     return false
   })
+  const [useArchivedUrls, setUseArchivedUrls] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const saved = localStorage.getItem('useArchivedUrls')
+      return saved === 'true'
+    }
+    return false
+  })
+  const initialUseLocalImages = useRef(null)
+  const initialUseArchivedUrls = useRef(null)
+
+  function settingsMenuToggle(isOpen) {
+    setIsSettingsOpen(isOpen)
+    if (isOpen) {
+      // Save values when modal opens
+      initialUseLocalImages.current = useLocalImages
+      initialUseArchivedUrls.current = useArchivedUrls
+    }
+    if (!isOpen) {
+      // Compare when modal closes
+      if (useLocalImages !== initialUseLocalImages.current || 
+          useArchivedUrls !== initialUseArchivedUrls.current) {
+        window.location.reload()
+        
+      }
+    }
+  }
+
   const navigate = useNavigate()
   const location = useLocation()
 
@@ -66,7 +93,7 @@ function AppLayout({ children, currentPath }) {
               </nav>
               <div className="flex items-center gap-2">
                 <button
-                  onClick={() => setIsSettingsOpen(true)}
+                  onClick={() => settingsMenuToggle(true)}
                   className="flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
                   aria-label="Open settings"
                   title="Settings"
@@ -91,9 +118,11 @@ function AppLayout({ children, currentPath }) {
       {/* Settings Modal */}
       <SettingsModal
         isOpen={isSettingsOpen}
-        onClose={() => setIsSettingsOpen(false)}
+        onClose={() => settingsMenuToggle(false)}
         useLocalImages={useLocalImages}
         setUseLocalImages={setUseLocalImages}
+        useArchivedUrls={useArchivedUrls}
+        setUseArchivedUrls={setUseArchivedUrls}
       />
 
       {/* Fixed Footer */}
@@ -148,6 +177,13 @@ function ComicsView() {
       return saved === 'true'
     }
     return false
+  })
+  const [useArchivedUrls, setUseArchivedUrls] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const saved = localStorage.getItem('useArchivedUrls')
+      return saved === 'true'
+    }
+    return true
   })
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
 
@@ -828,6 +864,7 @@ function ComicsView() {
                   comicsData={comicsData}
                   comicsIndex={comicsIndex}
                   useLocalImages={useLocalImages}
+                  useArchivedUrls={useArchivedUrls}
                 />
               </div>
             </div>
@@ -907,9 +944,11 @@ function ComicsView() {
       {/* Settings Modal */}
       <SettingsModal
         isOpen={isSettingsOpen}
-        onClose={() => setIsSettingsOpen(false)}
+        onClose={() => settingsMenuToggle(false)}
         useLocalImages={useLocalImages}
         setUseLocalImages={setUseLocalImages}
+        useArchivedUrls={useArchivedUrls}
+        setUseArchivedUrls={setUseArchivedUrls}
       />
 
       {/* Background Loading Status */}

--- a/src/components/ArchiveUrlToggle.jsx
+++ b/src/components/ArchiveUrlToggle.jsx
@@ -1,0 +1,40 @@
+function ArchivedUrlToggle({ value, onChange }) {
+  const handleToggle = (e) => {
+    const newValue = e.target.checked
+    localStorage.setItem('useArchivedUrls', newValue.toString())
+    onChange(newValue)
+  }
+
+  return (
+    <label className="flex items-center gap-3 cursor-pointer group">
+      <div className="relative">
+        <input
+          type="checkbox"
+          checked={value}
+          onChange={handleToggle}
+          className="sr-only"
+        />
+        <div className={`w-11 h-6 rounded-full transition-colors duration-200 ${
+          value ? 'bg-blue-600 dark:bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'
+        }`}>
+          <div className={`w-5 h-5 bg-white dark:bg-gray-200 rounded-full shadow-md transform transition-transform duration-200 mt-0.5 ${
+            value ? 'translate-x-5' : 'translate-x-0.5'
+          }`}></div>
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <svg className={`w-5 h-5 transition-colors ${value ? 'text-blue-600 dark:text-blue-400' : 'text-gray-400 dark:text-gray-500'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4" />
+        </svg>
+        <span className={`text-sm font-medium transition-colors ${
+          value ? 'text-blue-600 dark:text-blue-400' : 'text-gray-600 dark:text-gray-400'
+        }`}>
+          Use Archived urls
+        </span>
+      </div>
+    </label>
+  )
+}
+
+export default ArchivedUrlToggle
+

--- a/src/components/ComicDisplay.jsx
+++ b/src/components/ComicDisplay.jsx
@@ -36,13 +36,13 @@ function ComicDisplay({ date, comic, comicsData, comicsIndex, useLocalImages, us
     
     // When local images are disabled, use archive.org URL
     return comicData.originalimageurl || ''
-  }, [useLocalImages])
+  }, [useLocalImages,useArchivedUrls])
 
   // Reset error state when comic or image source changes
   useEffect(() => {
     setImageError(false)
     setIsArchiveOrgError(false)
-  }, [date, comic, useLocalImages])
+  }, [date, comic, useLocalImages,useArchivedUrls])
 
   // Preload adjacent images
   useEffect(() => {

--- a/src/components/ComicDisplay.jsx
+++ b/src/components/ComicDisplay.jsx
@@ -150,7 +150,7 @@ function ComicDisplay({ date, comic, comicsData, comicsIndex, useLocalImages, us
                     </svg>
                   </div>
                   <p className="text-sm text-gray-600 dark:text-gray-400">
-                    Image could not be loaded
+                    Image could not be loaded. Try using the archived urls in settings.
                   </p>
                 </div>
               )

--- a/src/components/ComicDisplay.jsx
+++ b/src/components/ComicDisplay.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useCallback, useState } from 'react'
 
-function ComicDisplay({ date, comic, comicsData, comicsIndex, useLocalImages }) {
+function ComicDisplay({ date, comic, comicsData, comicsIndex, useLocalImages, useArchivedUrls}) {
   const [showTranscript, setShowTranscript] = useState(false)
   const [imageError, setImageError] = useState(false)
   const [isArchiveOrgError, setIsArchiveOrgError] = useState(false)
@@ -25,6 +25,13 @@ function ComicDisplay({ date, comic, comicsData, comicsIndex, useLocalImages }) 
       }
       // If no local image available, return empty string (will trigger error state)
       return ''
+    }
+    // console.log(useArchivedUrls)
+    if (!useArchivedUrls) {
+      return comicData.originalimageurl.replace(
+        /^https?:\/\/web\.archive\.org\/web\/[^/]+\/(https?:\/\/.+)$/,
+        '$1'
+      );
     }
     
     // When local images are disabled, use archive.org URL
@@ -128,7 +135,7 @@ function ComicDisplay({ date, comic, comicsData, comicsIndex, useLocalImages }) 
                     Image unavailable
                   </p>
                   <p className="text-sm text-gray-600 dark:text-gray-400">
-                    Sorry, archive.org appears to be down. The image cannot be loaded at this time.
+                    Unable to load images from Archive.org. Try loading them from the original syndicate from the settings menu.
                   </p>
                 </div>
               )

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -1,7 +1,8 @@
 import { useEffect } from 'react'
 import ImageSourceToggle from './ImageSourceToggle'
+import ArchivedUrlToggle from './ArchiveUrlToggle'
 
-function SettingsModal({ isOpen, onClose, useLocalImages, setUseLocalImages }) {
+function SettingsModal({ isOpen, onClose, useLocalImages, setUseLocalImages, useArchivedUrls, setUseArchivedUrls}) {
   // Close modal on Escape key
   useEffect(() => {
     const handleEscape = (e) => {
@@ -69,6 +70,11 @@ function SettingsModal({ isOpen, onClose, useLocalImages, setUseLocalImages }) {
                   Note: Local images are only available for localhost deployments. This option is intended for researchers who have saved or scraped all comics to a local folder on their computer.
                 </p>
               )}
+              <ArchivedUrlToggle value={useArchivedUrls} onChange={setUseArchivedUrls} />
+              <p className="mt-3 text-xs text-gray-500 dark:text-gray-400 italic">
+                Loading images from {useArchivedUrls ? "Archive.org" : "the Andrews McMeel Syndication"}
+              </p>
+                
             </div>
           </div>
         </div>


### PR DESCRIPTION
While working on #2 , I kept getting rate limited by archive.org because I would load lots of comics very fast, so locally I stripped the image urls to pull from the original syndicate instead, since those are still available and load very quickly without rate limits. 

In this branch added toggle in settings to choose whether or not to use archive.org urls. I also made the page reload when a setting in changed.
<img width="429" height="188" alt="Screenshot 2026-04-15 at 5 35 16 PM" src="https://github.com/user-attachments/assets/16c1a756-d669-4fd0-a00a-c6b3cf727e23" />
<img width="644" height="111" alt="Screenshot 2026-04-15 at 5 46 55 PM" src="https://github.com/user-attachments/assets/a0f67c92-9783-49f1-8383-b48cb1fa8a46" />
<img width="682" height="113" alt="Screenshot 2026-04-15 at 5 46 29 PM" src="https://github.com/user-attachments/assets/4768f580-51de-43da-ade4-bc5436300e0d" />
